### PR TITLE
containers: pin Debian and its software

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -9,10 +9,6 @@ on:
     branches:
       - main
 
-  # Update the image every month
-  schedule:
-    - cron: '0 0 1 * *'
-
 jobs:
   build:
     name: Build, test and push
@@ -51,6 +47,10 @@ jobs:
         with:
           images: |
             ${{ env.builder_img }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Generate metadata for the tester image
         id: tester_meta
@@ -58,6 +58,10 @@ jobs:
         with:
           images: |
             ${{ env.tester_img }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
@@ -77,6 +81,8 @@ jobs:
           push: true
           tags: ${{ env.tester_test_tag }}
           target: tester
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and load builder image
         uses: docker/build-push-action@v2
@@ -87,6 +93,8 @@ jobs:
           push: true
           tags: ${{ env.builder_test_tag }}
           target: builder
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # TODO: Test the image on nimskull
 
@@ -109,6 +117,8 @@ jobs:
           tags: ${{ steps.tester_meta.outputs.tags }}
           labels: ${{ steps.tester_meta.outputs.labels }}
           target: tester
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Push builder image
         if: github.event_name != 'pull_request'
@@ -121,3 +131,5 @@ jobs:
           tags: ${{ steps.builder_meta.outputs.tags }}
           labels: ${{ steps.builder_meta.outputs.labels }}
           target: builder
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -3,11 +3,6 @@
 # This file is licensed under the terms of the MIT license. See "license.txt"
 # included in this distribution for more information.
 
-# The name of the Debian release being used.
-#
-# These images tracks LTS releases.
-ARG debian_release=buster
-
 # Update this monthly
 #
 # If you alter this line formatting or move it away from the top, update
@@ -79,7 +74,22 @@ RUN set -eux \
 
 # --- Image used for building the compiler
 
-FROM docker.io/debian:${debian_release}-slim as builder
+FROM docker.io/debian:buster-20211201-slim as builder
+
+# Switch to snapshot repositories to ensure that the image is reproducible
+#
+# These repositories are kept as comments in /etc/apt/sources.list, of which we
+# use sed to switch to them
+RUN sed \
+      # Delete all repository lines
+      -e '/^deb /d' \
+      # Uncomment the snapshot lines
+      -e 's/^# \(deb.*\)/\1/g' \
+      # Do this inline, saving the old file as .non-snapshot
+      -i.non-snapshot \
+      /etc/apt/sources.list \
+    # Since we switch to snapshot, Check-Valid-Until has to be disabled
+    && echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/container-snapshot
 
 # Update APT then install compiler build dependencies
 RUN apt-get update \


### PR DESCRIPTION
To ensure reproducibility, we pin the Debian base and its dependency by
switching to a snapshot of the Debian repository.

This slows down the build, which is why caching is enabled for this one.
And since the image is static, there is no need for monthly builds.