### PR TITLE
containers: change nodejs updater condition

### DIFF
--- a/.github/workflows/containers-updates.yml
+++ b/.github/workflows/containers-updates.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./containers/check-node-updates.sh
 
       - name: Create PR if needed (only on scheduled runs)
-        if: github.event == 'schedule'
+        if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == 'main')
         uses: peter-evans/create-pull-request@v3.12.1
         with:
           commit-message: |


### PR DESCRIPTION
Previously the conditional was faulty and checked the event object instead of the event name.

This commit fixes that and changed the condition to also trigger on pushes to main.